### PR TITLE
This corrects a bug: missing "," between ks and fishmethods packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Imports:
     propagate,
     parallel,
     doParallel,
-    ks
+    ks,
     fishmethods
 License: GPL-3
 BugReports: https://github.com/rschwamborn/fishboot/issues


### PR DESCRIPTION
This corrects a bug: missing "," between ks and fishmethods packages